### PR TITLE
Removing unnecessary LethalSettings dependency.

### DIFF
--- a/package/mirage-core/manifest.json
+++ b/package/mirage-core/manifest.json
@@ -7,7 +7,6 @@
         "BepInEx-BepInExPack-5.4.2100",
         "Bobbie-NAudio-2.2.2",
 		"qwbarch-NAudioLame-2.1.1",
-		"Hamunii-AutoHookGenPatcher-1.0.4",
-        "willis81808-LethalSettings-1.4.0"
+		"Hamunii-AutoHookGenPatcher-1.0.4"
     ]
 }


### PR DESCRIPTION
LethalSettings does not need to be pulled in as a dependency. Since it is a soft dependency, it can be advertised as an option, but forcing optional installs in can cause incompatibilities (such as with Meltdown). I mostly don't want it because it clutters my pause menu when I already have LethalConfig, but I frequently just edit the json configs anyway or use a mod manager.

tl;dr: If it's not a requirement, don't make it one, please.