### PR TITLE
Fix: Selling at company building wouldn't work anymore.

### DIFF
--- a/package/mirage-lc/manifest.json
+++ b/package/mirage-lc/manifest.json
@@ -1,11 +1,11 @@
 {
     "name": "Mirage",
-    "version_number": "1.29.0",
+    "version_number": "1.29.1",
     "website_url": "https://github.com/qwbarch/mirage",
     "description": "Voice mimicking where all players hear the same voice, with a focus on masked enemies. Alternative to Skinwalkers + MaskedEnemyOverhaul.",
     "dependencies": [
         "qwbarch-MirageCore-1.0.4",
-        "VirusTLNR-MaskedInvisFix-0.0.2",
-        "ButteryStancakes-MaskFixes-1.3.1"
+        "VirusTLNR-MaskedInvisFix-0.0.3",
+        "ButteryStancakes-MaskFixes-1.6.0"
     ]
 }

--- a/package/mirage-lc/plugin/PluginInfo.cs
+++ b/package/mirage-lc/plugin/PluginInfo.cs
@@ -3,6 +3,6 @@ namespace Mirage.Plugin
     static class PluginInfo {
         public const string PLUGIN_NAME = "Mirage";
         public const string PLUGIN_ID = "qwbarch." + PLUGIN_NAME;
-        public const string PLUGIN_VERSION = "1.28.0";
+        public const string PLUGIN_VERSION = "1.29.1";
     }
 }

--- a/package/mirage-lc/src/Mirage.fsproj
+++ b/package/mirage-lc/src/Mirage.fsproj
@@ -25,7 +25,7 @@
     <ProjectReference Include="../../silero-vad/src/Silero.fsproj" />
     <PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.1" PrivateAssets="all" />
     <PackageReference Include="BepInEx.Core" Version="5.4.21" />
-    <PackageReference Include="LethalCompany.GameLibs.Steam" Version="73.0.0-ngd.0" Publicize="true" />
+    <PackageReference Include="LethalCompany.GameLibs.Steam" Version="81.0.0-ngd.0" Publicize="true" />
     <PackageReference Include="FSharpPlus" Version="1.6.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="LethalSettings" Version="1.4.0" Publicize="true" />

--- a/package/mirage-lc/src/Mirage/Hook/MaskedPlayerEnemy.fs
+++ b/package/mirage-lc/src/Mirage/Hook/MaskedPlayerEnemy.fs
@@ -101,9 +101,7 @@ let hookMaskedEnemy maskedAnimationController =
                     totalWeight <- totalWeight + weight
                     let spawnChance = float weight / float totalWeight * 100.0
                     logs.Add $"Level: {level.PlanetName}. Weight: {weight}. SpawnChance: {spawnChance:F2}%%"
-                    let enemy = SpawnableEnemyWithRarity()
-                    enemy.rarity <- weight
-                    enemy.enemyType <- enemyType
+                    let enemy = SpawnableEnemyWithRarity(enemyType, weight)
                     enemy.enemyType.MaxCount <- localConfig.MaxMaskedSpawns.Value
                     level.Enemies.Add enemy
             logInfo <| "Adjusting spawn weights for masked enemies:\n" + String.Join("\n", logs)


### PR DESCRIPTION
The method signature of SpawnableEnemyWithRarity was still from an older version of LethalCompany.GameLibs.Steam. The v80/v81 version has 2 arguments which probably caused the issues. After applying the changes in this PR I tested it with a barebones setup (only Mirage dependencies + MoreCompany) and selling seemed to work again.

Fixes #195 