### PR TITLE
Fix NullReferenceException on StartOfRound.Awake for LC v81

### DIFF
--- a/package/mirage-lc/src/Mirage/Hook/Config.fs
+++ b/package/mirage-lc/src/Mirage/Hook/Config.fs
@@ -30,9 +30,14 @@ let syncConfig () =
         let networkManager = GameNetworkManager.Instance.GetComponent<NetworkManager>()
         if isNotNull networkManager then
             for prefab in networkManager.NetworkConfig.Prefabs.m_Prefabs do
-                let enemyAI = prefab.Prefab.GetComponent<EnemyAI>()
-                if isNotNull enemyAI then
-                    localConfig.RegisterEnemy enemyAI
+                // In LC v81 (Netcode for GameObjects), NetworkConfig.Prefabs can contain
+                // entries whose Prefab is null (e.g. override entries, or prefabs registered
+                // by other mods). Calling GetComponent on a null GameObject throws
+                // NullReferenceException, so guard before dereferencing.
+                if isNotNull prefab && isNotNull prefab.Prefab then
+                    let enemyAI = prefab.Prefab.GetComponent<EnemyAI>()
+                    if isNotNull enemyAI then
+                        localConfig.RegisterEnemy enemyAI
         initEnemiesLethalConfig
             (Assembly.GetExecutingAssembly())
             (getEnemyConfigEntries())

--- a/package/mirage-lc/src/Mirage/Hook/Config.fs
+++ b/package/mirage-lc/src/Mirage/Hook/Config.fs
@@ -25,12 +25,14 @@ let syncConfig () =
         revertSync()
     )
 
-    On.StartOfRound.add_Awake(fun orig self ->
+    On.StartOfRound.add_Start(fun orig self ->
         orig.Invoke self
-        for prefab in GameNetworkManager.Instance.GetComponent<NetworkManager>().NetworkConfig.Prefabs.m_Prefabs do
-            let enemyAI = prefab.Prefab.GetComponent<EnemyAI>()
-            if isNotNull enemyAI then
-                localConfig.RegisterEnemy enemyAI
+        let networkManager = GameNetworkManager.Instance.GetComponent<NetworkManager>()
+        if isNotNull networkManager then
+            for prefab in networkManager.NetworkConfig.Prefabs.m_Prefabs do
+                let enemyAI = prefab.Prefab.GetComponent<EnemyAI>()
+                if isNotNull enemyAI then
+                    localConfig.RegisterEnemy enemyAI
         initEnemiesLethalConfig
             (Assembly.GetExecutingAssembly())
             (getEnemyConfigEntries())


### PR DESCRIPTION
In LC v81, GameNetworkManager.Instance.GetComponent<NetworkManager>() returns null during StartOfRound.Awake because NetworkManager has not fully initialized yet at that point in the lifecycle.

Move the enemy prefab registration from add_Awake to add_Start, where NetworkManager is guaranteed to be available. Also add a null guard as a defensive measure.

Fixes the void spawn / player unable to move bug reported in issue #198 and the ship doors not opening bug in issue #193.