### PR TITLE
fix: microphone consumer dies on clients, silently disabling all recordings

### DIFF
--- a/package/mirage-lc/src/Mirage/Hook/Microphone.fs
+++ b/package/mirage-lc/src/Mirage/Hook/Microphone.fs
@@ -17,6 +17,7 @@ open Mirage.Core.Task.Fork
 open Mirage.Domain.Config
 open Mirage.Domain.Setting
 open Mirage.Domain.Null
+open Mirage.Domain.Logger
 
 let [<Literal>] MinAudioDurationMs = 150
 let [<Literal>] MinSilenceDurationMs = 2000
@@ -62,19 +63,29 @@ let private bufferChannel =
     let consumer () =
         forever <| fun () -> valueTask {
             let! input = readChannel channel
-            if isNotNull StartOfRound.Instance then
-                writeChannel processingChannel << ValueSome <|
-                    {   samples = input.samples
-                        format =
-                            {   sampleRate = input.sampleRate
-                                channels = input.channels
-                            }
-                        isReady = isReady
-                        isPlayerDead = StartOfRound.Instance.localPlayerController.isPlayerDead
-                        pushToTalkEnabled = IngamePlayerSettings.Instance.settings.pushToTalk
-                        isMuted = getDissonance().IsMuted
-                        allowRecordVoice = getSettings().allowRecordVoice
-                    }
+            try
+                let startOfRound = StartOfRound.Instance
+                let playerSettings = IngamePlayerSettings.Instance
+                let dissonance = getDissonance()
+                if isNotNull startOfRound
+                    && isNotNull startOfRound.localPlayerController
+                    && isNotNull playerSettings
+                    && isNotNull dissonance
+                then
+                    writeChannel processingChannel << ValueSome <|
+                        {   samples = input.samples
+                            format =
+                                {   sampleRate = input.sampleRate
+                                    channels = input.channels
+                                }
+                            isReady = isReady
+                            isPlayerDead = startOfRound.localPlayerController.isPlayerDead
+                            pushToTalkEnabled = playerSettings.settings.pushToTalk
+                            isMuted = dissonance.IsMuted
+                            allowRecordVoice = getSettings().allowRecordVoice
+                        }
+            with | error ->
+                logError $"Failed to process microphone data: {error}"
         }
     fork CancellationToken.None consumer
     channel


### PR DESCRIPTION
Clients never produce any voice recordings: `Mirage/Recording` stays empty and masked enemies never mimic them. Hosting works fine. There are no errors in the log, which I think is why this has been so hard to pin down — see #140, #91, #78 and #179.

### Cause

In `Mirage/Hook/Microphone.fs`, the `bufferChannel` consumer null-checks `StartOfRound.Instance` but then dereferences four things without checking any of them:

```fsharp
if isNotNull StartOfRound.Instance then
    ...
    isPlayerDead      = StartOfRound.Instance.localPlayerController.isPlayerDead
    pushToTalkEnabled = IngamePlayerSettings.Instance.settings.pushToTalk
    isMuted           = getDissonance().IsMuted
    allowRecordVoice  = getSettings().allowRecordVoice
```

When joining as a client there is a window where `StartOfRound.Instance` is already assigned while one of the others is still null. The `NullReferenceException` escapes the `forever` loop and silently terminates the fork. Nothing is ever written to `processingChannel` again for the rest of the session — and because the exception dies inside the channel machinery, nothing is logged.

### Evidence

I instrumented a running client with Harmony:

- `MicrophoneSubscriber.ReceiveMicrophoneData` was called continuously (~100 calls/s, 8589 total) — audio was arriving.
- `Silero.API.detectSpeech` was called **0 times** over the same period — the pipeline was already dead upstream of the voice detector.
- Forcing `isReady`, and confirming `isConfigReady`, `IsMuted = false`, `pushToTalk = false`, `isPlayerDead = false`, changed nothing.
- Calling `readMicrophone` again did not help, which is consistent with the dead consumer being the module-level `bufferChannel` one rather than the `processingChannel` one.
- Injecting the microphone data straight into `processingChannel` from outside the mod immediately restored recording: `detectSpeech` calls went `0 → 246`, peak probability `0.998`, and `.opus` files started appearing within seconds.

### Fix

Guard every dereference, and wrap the loop body in `try/with`. The guards fix this particular case; the `try/with` matters more, since today any transient exception there permanently disables recording for the whole session with no trace. Now it survives and logs.
